### PR TITLE
Mixed Image File Format

### DIFF
--- a/1.2/spec.md
+++ b/1.2/spec.md
@@ -44,7 +44,7 @@ The metadata table is used as a key/value store for settings. Five keys are **re
 * `type`: `overlay` or `baselayer`
 * `version`: The version of the tileset, as a plain number.
 * `description`: A description of the layer as plain text.
-* `format`: The image file format of the tile data: `png` or `jpg`
+* `format`: The image file format of the tile data: `png`, `jpg`, or `mixed`
 
 One row in `metadata` is **suggested** and, if provided, may enhance performance.
 


### PR DESCRIPTION
Propose adding a "mixed" image file format, like the MapServer or ArcGIS Server "MIXED" cache modes. This would indicate that the database contains both JPEG and PNG images, supporting a scenario--useful in overlay layers--where PNGs are used only where transparency is needed and JPEGs are used elsewhere. This minimizes cache size while guaranteeing that the layer will cleanly overlay on a basemap layer.
