### PR TITLE
2.0 spec

### DIFF
--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -53,10 +53,10 @@ The following keys are REQUIRED
 * `type`: `overlay` or `baselayer`
 * `version`: The version of the tileset, as a plain number.
 * `description`: A description of the layer as plain text.
-
-The following keys are RECOMMENDED
-
 * `format`: The MIME format of the tile data.
+
+The following keys is RECOMMENDED
+
 * `compression`: The type of compression applied on top of the tile data. The value SHALL a valid [HTTP Content](http://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding) name.
 
   Decoders MAY assume per-format defaults if the key is not present.

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -50,8 +50,6 @@ The metadata table is used as a key/value store for settings.
 The following keys are REQUIRED
 
 * `name`: The plain-english name of the tileset.
-* `type`: `overlay` or `baselayer`
-* `version`: The version of the tileset, as a plain number.
 * `description`: A description of the layer as plain text.
 * `format`: The MIME format of the tile data.
 
@@ -69,6 +67,8 @@ The following keys are OPTIONAL
   **left, bottom, right, top**. Example of the full earth: `-180.0,-85,180,85`.
 * `attribution`: An attribution string, which explains in English (and HTML) the sources of
   data and/or style for the map.
+* `version`: The version of the tileset, as a plain number.
+* `type`: `overlay` or `baselayer`
 
 Additional keys MAY be added, such as those in [UTFGrid-based interaction](https://github.com/mapbox/utfgrid-spec).
 

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -62,7 +62,7 @@ The metadata table is used as a key/value store for settings.
 
 The following keys are REQUIRED
 
-* `name`: The plain-english name of the tileset.
+* `name`: The natural language name of the tileset.
 * `description`: A description of the layer as plain text.
 * `format`: The MIME format of the tile data.
 

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -90,7 +90,7 @@ The `zoom_level`, `tile_column`, and `tile_row` columns MUST the
 [Tile Map Service Specification](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification) in
 their construction, except the [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) MUST be used.
 
-The `tile_data blob` column contains raw tile data in binary. If the `format` or `compression` metadata keys are present the tile data MUST be in that format and/or compression. Regardless of the presence of those metadata keys, all tile data MUST be in the same format and compression.
+The `tile_data blob` column contains raw tile data in binary. If the `compression` metadata keys is present the tile data MUST be in compression. If it is not present all tile data MUST still be in the same compression.
 
 ### Grids
 

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -89,6 +89,7 @@ The tiles table contains tiles and the values used to locate them.
 The `zoom_level`, `tile_column`, and `tile_row` columns MUST the
 [Tile Map Service Specification](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification) in
 their construction, except the [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) MUST be used.
+The `tile_row` coordinate is different from the `y` coordinate in the XYZ schema popularized by Google and OpenStreetMap.
 
 The `tile_data blob` column contains raw tile data in binary. If the `compression` metadata keys is present the tile data MUST be in compression. If it is not present all tile data MUST still be in the same compression.
 

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -16,6 +16,19 @@ MBTiles is a specification for storing tiled map data in
 MBTiles files, known as **tilesets**, MUST implement the specification below
 to ensure compatibility with devices.
 
+## Compatibility
+*This section is informative and does not add requirements to implementations*
+
+Because views may be used to produce the MBTiles schema two implementations
+may store tiles with different internal details, meaning one implementation
+may not be able to add to an existing file.
+
+As a container format, MBTiles can store any tiled data, so data can be stored
+that an implementation cannot do anything with. Additionally, an implementation
+is not required to handle all compressions the spec allows.
+
+Relying metadata keys not in the specification can cause compatibility problems.
+
 ## Database Specifications
 
 Tilesets SHALL be valid SQLite databases of

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -91,7 +91,7 @@ The `zoom_level`, `tile_column`, and `tile_row` columns MUST the
 their construction, except the [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) MUST be used.
 The `tile_row` coordinate is different from the `y` coordinate in the XYZ schema popularized by Google and OpenStreetMap.
 
-The `tile_data blob` column contains raw tile data in binary. If the `compression` metadata keys is present the tile data MUST be in compression. If it is not present all tile data MUST still be in the same compression.
+The `tile_data blob` column contains raw tile data in binary. If the `compression` metadata key is present the tile data MUST be in that compression. If it is not present all tile data for different tiles MUST still be in the same compression.
 
 ### Grids
 

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -1,0 +1,116 @@
+# MBTiles 2.0
+
+# Sub-sections:
+
+* **Interaction**: HTTP endpoints needed for implementing interactivity
+* **UTFGrid**: This specification relies on [UTFGrid 1.2](https://github.com/mapbox/utfgrid-spec) for interactivity.
+
+## Abstract
+
+MBTiles is a specification for storing tiled map data in
+[SQLite](http://sqlite.org/) databases for immediate usage and for transfer.
+MBTiles files, known as **tilesets**, must implement the specification below
+to ensure compatibility with devices.
+
+## Database Specifications
+
+Tilesets are expected to be valid SQLite databases of
+[version 3.0.0](http://sqlite.org/formatchng.html) or higher.
+Only core SQLite features are permitted; tilesets **cannot require extensions**.
+
+MBTiles databases can optionally use [the officially assigned magic number](http://www.sqlite.org/src/artifact?ci=trunk&filename=magic.txt)
+to be easily identified as MBTiles.
+
+## Database
+
+Note: the schemas outlined are meant to be followed as interfaces.
+SQLite views that produce compatible results are equally valid.
+For convenience, this specification refers to tables and virtual
+tables (views) as tables.
+
+### Metadata
+
+#### Schema
+
+The database is required to contain a table or view named `metadata`.
+
+This table must yield exactly two columns named `name` and
+`value`. A typical create statement for the `metadata` table:
+
+    CREATE TABLE metadata (name text, value text);
+
+#### Content
+
+The metadata table is used as a key/value store for settings. Five keys are **required**:
+
+* `name`: The plain-english name of the tileset.
+* `type`: `overlay` or `baselayer`
+* `version`: The version of the tileset, as a plain number.
+* `description`: A description of the layer as plain text.
+* `format`: The image file format of the tile data: `png` or `jpg`
+
+One row in `metadata` is **suggested** and, if provided, may enhance performance.
+
+* `bounds`: The maximum extent of the rendered map area. Bounds must define an
+  area covered by all zoom levels. The bounds are represented in `WGS:84` -
+  latitude and longitude values, in the OpenLayers Bounds format -
+  **left, bottom, right, top**. Example of the full earth: `-180.0,-85,180,85`.
+* `attribution`: An attribution string, which explains in English (and HTML) the sources of
+  data and/or style for the map.
+
+Several additional keys are supported for tilesets that implement
+[UTFGrid-based interaction](https://github.com/mapbox/utfgrid-spec).
+
+### Tiles
+
+#### Schema
+
+The database is required to contain a table named `tiles`.
+
+The table must yield four columns named `zoom_level`, `tile_column`,
+`tile_row`, and `tile_data`. A typical create statement for the `tiles` table:
+
+    CREATE TABLE tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob);
+
+#### Content
+
+The tiles table contains tiles and the values used to locate them.
+The `zoom_level`, `tile_column`, and `tile_row` columns follow the
+[Tile Map Service Specification](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification) in
+their construction, but in a restricted form:
+
+**The [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) profile is assumed**
+
+The `tile_data blob` column contains raw image data in binary.
+
+A subset of image file formats are permitted:
+
+* `png`
+* `jpg`
+
+### Grids
+
+_See the [UTFGrid specification](https://github.com/mapbox/utfgrid-spec) for
+implementation details of grids and interaction metadata itself: the MBTiles
+specification is only concerned with storage._
+
+#### Schema
+
+The database can have optional tables named `grids`, `grid_data`.
+
+The `grids` table must yield four columns named `zoom_level`, `tile_column`,
+`tile_row`, and `grid`. A typical create statement for the `grids` table:
+
+    CREATE TABLE grids (zoom_level integer, tile_column integer, tile_row integer, grid blob);
+
+The `grid_data` table must yield five columns named `zoom_level`, `tile_column`,
+`tile_row`, `key_name`, and `key_json`. A typical create statement for the `grid_data` table:
+
+    CREATE TABLE grid_data (zoom_level integer, tile_column integer, tile_row integer, key_name text, key_json text);
+
+#### Content
+
+The `grids` table contains UTFGrid data, gzip compressed.
+
+The `grid_data` table contains grid key to value mappings, with values encoded
+as JSON objects.

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -54,19 +54,9 @@ The following keys are REQUIRED
 * `version`: The version of the tileset, as a plain number.
 * `description`: A description of the layer as plain text.
 
-The following key is RECOMMENDED
+The following keys are RECOMMENDED
 
-* `format`: The file format of the tile data.
-
-  If the format is one of the following common formats, the string given in this table list SHOULD be used
-
-  * `jpg` for JPEG images
-  * `png` for PNG images
-  * `geojson` for [GeoJSON](http://geojson.org/) encoded data
-  * `topojson` for [TopoJSON](https://github.com/mbostock/topojson) encoded data
-  * `o5m` for [o5m](http://wiki.openstreetmap.org/wiki/O5m) encoded data in the OpenStreetMap data model
-  * `mvt` for [Mapbox Vector Tiles](https://github.com/mapbox/vector-tile-spec)
-
+* `format`: The MIME format of the tile data.
 * `compression`: The type of compression applied on top of the tile data. The value SHALL a valid [HTTP Content](http://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding) name.
 
   Decoders MAY assume per-format defaults if the key is not present.

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -45,15 +45,29 @@ This table MUST yield exactly two columns named `name` and
 
 #### Content
 
-The metadata table is used as a key/value store for settings. It MUST have the following five keys:
+The metadata table is used as a key/value store for settings.
+
+The following keys are REQUIRED
 
 * `name`: The plain-english name of the tileset.
 * `type`: `overlay` or `baselayer`
 * `version`: The version of the tileset, as a plain number.
 * `description`: A description of the layer as plain text.
-* `format`: The image file format of the tile data: `png` or `jpg`
 
-The following keys in `metadata` are OPTIONAL
+The following key is RECOMMENDED
+
+* `format`: The file format of the tile data.
+
+  If the format is one of the following common formats, the string given in this table list SHOULD be used
+
+  * `jpg` for JPEG images
+  * `png` for PNG images
+  * `geojson` for [GeoJSON](http://geojson.org/) encoded data
+  * `topojson` for [TopoJSON](https://github.com/mbostock/topojson) encoded data
+  * `o5m` for [o5m](http://wiki.openstreetmap.org/wiki/O5m) encoded data in the OpenStreetMap data model
+  * `mvt` for [Mapbox Vector Tiles](https://github.com/mapbox/vector-tile-spec)
+
+The following keys are OPTIONAL
 
 * `bounds`: The maximum extent of the rendered map area. Bounds must define an
   area covered by all zoom levels. The bounds are represented in `WGS:84` -
@@ -82,12 +96,7 @@ The `zoom_level`, `tile_column`, and `tile_row` columns MUST the
 [Tile Map Service Specification](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification) in
 their construction, except the [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) MUST be used.
 
-The `tile_data blob` column contains raw image data in binary.
-
-A subset of image file formats are permitted:
-
-* `png`
-* `jpg`
+The `tile_data blob` column contains raw tile data in binary. If the `format` metadata key is present the tile data MUST be in that format.
 
 ### Grids
 

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -67,6 +67,10 @@ The following key is RECOMMENDED
   * `o5m` for [o5m](http://wiki.openstreetmap.org/wiki/O5m) encoded data in the OpenStreetMap data model
   * `mvt` for [Mapbox Vector Tiles](https://github.com/mapbox/vector-tile-spec)
 
+* `compression`: The type of compression applied on top of the tile data. The value SHALL a valid [HTTP Content](http://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding) name.
+
+  Decoders MAY assume per-format defaults if the key is not present.
+
 The following keys are OPTIONAL
 
 * `bounds`: The maximum extent of the rendered map area. Bounds must define an

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -90,7 +90,7 @@ The `zoom_level`, `tile_column`, and `tile_row` columns MUST the
 [Tile Map Service Specification](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification) in
 their construction, except the [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) MUST be used.
 
-The `tile_data blob` column contains raw tile data in binary. If the `format` metadata key is present the tile data MUST be in that format.
+The `tile_data blob` column contains raw tile data in binary. If the `format` or `compression` metadata keys are present the tile data MUST be in that format and/or compression. Regardless of the presence of those metadata keys, all tile data MUST be in the same format and compression.
 
 ### Grids
 

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -78,6 +78,9 @@ The following keys are OPTIONAL
   area covered by all zoom levels. The bounds are represented in `WGS:84` -
   latitude and longitude values, in the OpenLayers Bounds format -
   **left, bottom, right, top**. Example of the full earth: `-180.0,-85,180,85`.
+* `center`: The longitude, latitude, and zoom level of the default view of the map. Example: -1.48,51.87,13
+* `minzoom`: The lowest zoom level for which the tileset provides data. If present there MUST be no tiles with a lower `zoom_level`.
+* `maxzoom`: The highest zoom level for which the tileset provides data. If present there MUST be no tiles with a higher `zoom_level`.
 * `attribution`: An attribution string, which explains in English (and HTML) the sources of
   data and/or style for the map.
 * `version`: The version of the tileset, as a plain number.

--- a/2.0/spec.md
+++ b/2.0/spec.md
@@ -1,5 +1,9 @@
 # MBTiles 2.0
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in
+this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
 # Sub-sections:
 
 * **Interaction**: HTTP endpoints needed for implementing interactivity
@@ -9,22 +13,22 @@
 
 MBTiles is a specification for storing tiled map data in
 [SQLite](http://sqlite.org/) databases for immediate usage and for transfer.
-MBTiles files, known as **tilesets**, must implement the specification below
+MBTiles files, known as **tilesets**, MUST implement the specification below
 to ensure compatibility with devices.
 
 ## Database Specifications
 
-Tilesets are expected to be valid SQLite databases of
+Tilesets SHALL be valid SQLite databases of
 [version 3.0.0](http://sqlite.org/formatchng.html) or higher.
-Only core SQLite features are permitted; tilesets **cannot require extensions**.
+Only core SQLite features are permitted; tilesets SHALL NOT require extensions.
 
-MBTiles databases can optionally use [the officially assigned magic number](http://www.sqlite.org/src/artifact?ci=trunk&filename=magic.txt)
+MBTiles tilesets MAY use [the officially assigned magic number](http://www.sqlite.org/src/artifact?ci=trunk&filename=magic.txt)
 to be easily identified as MBTiles.
 
 ## Database
 
 Note: the schemas outlined are meant to be followed as interfaces.
-SQLite views that produce compatible results are equally valid.
+SQLite views that produce compatible results MAY be used instead.
 For convenience, this specification refers to tables and virtual
 tables (views) as tables.
 
@@ -32,16 +36,16 @@ tables (views) as tables.
 
 #### Schema
 
-The database is required to contain a table or view named `metadata`.
+The database MUST contain a table or view named `metadata`.
 
-This table must yield exactly two columns named `name` and
+This table MUST yield exactly two columns named `name` and
 `value`. A typical create statement for the `metadata` table:
 
     CREATE TABLE metadata (name text, value text);
 
 #### Content
 
-The metadata table is used as a key/value store for settings. Five keys are **required**:
+The metadata table is used as a key/value store for settings. It MUST have the following five keys:
 
 * `name`: The plain-english name of the tileset.
 * `type`: `overlay` or `baselayer`
@@ -49,7 +53,7 @@ The metadata table is used as a key/value store for settings. Five keys are **re
 * `description`: A description of the layer as plain text.
 * `format`: The image file format of the tile data: `png` or `jpg`
 
-One row in `metadata` is **suggested** and, if provided, may enhance performance.
+The following keys in `metadata` are OPTIONAL
 
 * `bounds`: The maximum extent of the rendered map area. Bounds must define an
   area covered by all zoom levels. The bounds are represented in `WGS:84` -
@@ -58,16 +62,15 @@ One row in `metadata` is **suggested** and, if provided, may enhance performance
 * `attribution`: An attribution string, which explains in English (and HTML) the sources of
   data and/or style for the map.
 
-Several additional keys are supported for tilesets that implement
-[UTFGrid-based interaction](https://github.com/mapbox/utfgrid-spec).
+Additional keys MAY be added, such as those in [UTFGrid-based interaction](https://github.com/mapbox/utfgrid-spec).
 
 ### Tiles
 
 #### Schema
 
-The database is required to contain a table named `tiles`.
+The database MUST contain a table named `tiles`.
 
-The table must yield four columns named `zoom_level`, `tile_column`,
+The table MUST yield four columns named `zoom_level`, `tile_column`,
 `tile_row`, and `tile_data`. A typical create statement for the `tiles` table:
 
     CREATE TABLE tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob);
@@ -75,11 +78,9 @@ The table must yield four columns named `zoom_level`, `tile_column`,
 #### Content
 
 The tiles table contains tiles and the values used to locate them.
-The `zoom_level`, `tile_column`, and `tile_row` columns follow the
+The `zoom_level`, `tile_column`, and `tile_row` columns MUST the
 [Tile Map Service Specification](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification) in
-their construction, but in a restricted form:
-
-**The [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) profile is assumed**
+their construction, except the [global-mercator](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator) (aka Spherical Mercator) MUST be used.
 
 The `tile_data blob` column contains raw image data in binary.
 
@@ -96,21 +97,21 @@ specification is only concerned with storage._
 
 #### Schema
 
-The database can have optional tables named `grids`, `grid_data`.
+The database MAY have optional tables named `grids` and `grid_data`.
 
-The `grids` table must yield four columns named `zoom_level`, `tile_column`,
+The `grids` table MUST yield four columns named `zoom_level`, `tile_column`,
 `tile_row`, and `grid`. A typical create statement for the `grids` table:
 
     CREATE TABLE grids (zoom_level integer, tile_column integer, tile_row integer, grid blob);
 
-The `grid_data` table must yield five columns named `zoom_level`, `tile_column`,
+The `grid_data` table MUST yield five columns named `zoom_level`, `tile_column`,
 `tile_row`, `key_name`, and `key_json`. A typical create statement for the `grid_data` table:
 
     CREATE TABLE grid_data (zoom_level integer, tile_column integer, tile_row integer, key_name text, key_json text);
 
 #### Content
 
-The `grids` table contains UTFGrid data, gzip compressed.
+The `grids` table MUST contain UTFGrid data, gzip compressed.
 
-The `grid_data` table contains grid key to value mappings, with values encoded
+The `grid_data` table MUST contain grid key to value mappings, with values encoded
 as JSON objects.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,16 @@ for compliance.
 * The format will switch tile ordering to the XYZ schema popularized by
   OpenStreetMap and away from the Tile Map Service specification.
 
+## 2.0
+
+* Allow data other than PNG and JPEG images to be stored in tilesets
+* Use MIME type for `format` metadata.
+* Added RECOMMENDED `compression` metadata.
+
 ## 1.1
 
-* `name='format'` row **required** in `metadata` table.
-* `name='bounds'` row suggested in `metadata` table.
+* Made `format` metadata REQUIRED.
+* Added OPTIONAL `bounds` metadata.
 * optional UTFGrid-based interaction spec.
 
 # Concept

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ there are no royalties, restrictions, or requirements.
 * Will White (willwhite)
 * Konstantin Kaefer (kkaefer)
 * Justin Miller (incanus)
+* Paul Norman (pnorman)

--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@ for compliance.
 
 # Changelog
 
-## Roadmap
-
-* The format will switch tile ordering to the XYZ schema popularized by
-  OpenStreetMap and away from the Tile Map Service specification.
-
 ## 2.0
 
 * Allow data other than PNG and JPEG images to be stored in tilesets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MBTiles Specification
 
-MBTiles is a specification for storing tiled map data in
+MBTiles is a specification for storing arbitrary tiled map data in
 [SQLite](http://sqlite.org/) databases for immediate usage and for transfer.
 MBTiles files, known as **tilesets**, must implement the specification below
 to ensure compatibility with devices.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ for compliance.
 # Concept
 
 MBTiles is a compact, restrictive specification. It supports only
-tiled data, including image tiles and interactivity grid tiles. Only the
+tiled data, including arbitrary tile data and interactivity grid tiles. Only the
 Spherical Mercator projection is supported for presentation - tile display -
 and only latitude-longitude coordinates are supported for metadata such
 as bounds and centers.
@@ -46,9 +46,12 @@ It is a minimum specification - only specifying the ways in which data
 must be retrievable. Thus MBTiles files can internally compress and optimize
 data, and construct views that adhere to the MBTiles specification.
 
+As a container format for arbitrary tiled data different implementations can
+use it for storing different types of data
+
 Unlike [Spatialite](http://www.gaia-gis.it/spatialite/), GeoJSON,
 and Rasterlite, MBTiles is not raw data storage - it is storage
-for presentational data, like rendered map tiles.
+for tiled data, like rendered map tiles.
 
 One MBTiles file represents a single tileset, optionally including grids
 of interactivity data. Multiple tilesets - layers, or maps in other terms,


### PR DESCRIPTION
Fixes #43 
Fixes #44
Fixes #31 
Fixes #28 
Closes #47 (imo)

This is a draft of a 2.0 spec which addresses tile formats and compression.

Unaddressed are spec versioning (#3), ~~tileset versioning (#31), and tileset type (#28)~~ since no decision was made on if those changes should be accepted or not.

For a diff of 1.2 to 2.0, see https://github.com/mapbox/mbtiles-spec/compare/14942c649e4cff48d3b0c393f856d7681890594a...pnorman:2.0

CC @hallahan @blair1618 @systemed
