### PR TITLE
 Added 'tilepixelratio' metadata key info

### DIFF
--- a/1.3/spec.md
+++ b/1.3/spec.md
@@ -78,7 +78,7 @@ The `metadata` table SHOULD contain these four rows:
 * `minzoom` (number): The lowest zoom level for which the tileset provides data
 * `maxzoom` (number): The highest zoom level for which the tileset provides data
 
-The `metadata` table MAY contain these four rows:
+The `metadata` table MAY contain these five rows:
 
 * `attribution` (HTML string): An attribution string, which explains the sources of
   data and/or style for the map.
@@ -86,6 +86,8 @@ The `metadata` table MAY contain these four rows:
 * `type` (string): `overlay` or `baselayer`
 * `version` (number): The version of the tileset.
   This refers to a revision of the tileset itself, not of the MBTiles specification.
+* `tilepixelratio` (floating-point number): The pixel ratio of the tileset.
+  If not specified, `1.0` is assumed. For @2x HiDPI tiles use `2.0`.
 
 If the `format` is `pbf`, the `metadata` table MUST contain this row:
 

--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ there are no royalties, restrictions, or requirements.
 * Paul Norman (pnorman)
 * Blake Thompson (flippmoke)
 * Will White (willwhite)
+* Martin Tůma (tumic0)


### PR DESCRIPTION
For raster HiDPI tiles, a definition of the tile pixel ratio is required. This proposal adds such metadata key/value to the specification. The key name reflects the 'industry standard' (e.g. OpenLayers, GPXSee) in naming this tile set parameter while the floating-point value type enables maximal flexibility in tile scaling.